### PR TITLE
chore: migrate dependabot-agent caller to new orchestrator (PS-4722)

### DIFF
--- a/.github/workflows/dependabot-agent.yml
+++ b/.github/workflows/dependabot-agent.yml
@@ -4,20 +4,16 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
 
-# contents: read is sufficient since Dependabot only manages github-actions
-# updates here — no lockfile or format remediation push-back needed.
 permissions:
   contents: write
   pull-requests: write
+  actions: read
+  checks: read
 
 jobs:
   dependabot:
     if: |
-      (github.actor == 'dependabot[bot]' || github.actor == 'app/dependabot') &&
+      github.actor == 'dependabot[bot]' &&
       startsWith(github.event.pull_request.head.ref, 'dependabot/')
-    uses: unbounce/agentic-tools/.github/workflows/dependabot-agent-shared.yml@v1
-    with:
-      ecosystem: none
-    secrets:
-      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+    uses: unbounce/agentic-tools/.github/workflows/dependabot-agent.yml@v1
+    secrets: inherit


### PR DESCRIPTION
## Summary

- Caller-side change companion to [unbounce/agentic-tools#34](https://github.com/unbounce/agentic-tools/pull/34) — part of [PS-4722](https://unbounce.atlassian.net/browse/PS-4722).
- Drops the obsolete `ecosystem` input (the new orchestrator infers autofix dispatch from the dependabot branch name + manifest detection at run time).
- Adds `actions: read` and `checks: read` permissions (needed for `gh run view --log-failed` on sibling workflows and the `statusCheckRollup` query).
- Switches to `secrets: inherit` so the new `AGENTIC_TOOLS_TOKEN` and `DD_API_KEY` secrets flow through without per-secret enumeration.
- Updates `uses:` ref to the renamed shared workflow file (`dependabot-agent.yml`, no `-shared` suffix).

## Behaviour after this merges

The shared workflow's `dry_run` defaults to `true`. The agent will produce a job summary + Datadog event for the next Dependabot PR but take no side effects (no merge, no push, no comment, no Slack). The per-phase rollout flips `dry_run: false` for this repo when its phase arrives.

## Test plan

- [ ] After merge + agentic-tools#34 + `@v1` retag, confirm the next Dependabot PR in this repo runs the new workflow in dry_run mode with a populated job summary and no side effects
- [ ] Phase flip to `dry_run: false` happens in a follow-up PR

[PS-4722]: https://unbounce.atlassian.net/browse/PS-4722?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ