### PR TITLE
golden-path: manifest-distribute

### DIFF
--- a/entity.datadog.yaml
+++ b/entity.datadog.yaml
@@ -1,0 +1,19 @@
+apiVersion: v3
+kind: service
+metadata:
+  name: omniauth-constantcontact2
+  displayName: Omniauth Constantcontact2
+  tags:
+    - archetype:library
+    - gp-status:active
+    - managed-by:golden-path
+  owner: platform-services
+  links:
+    - name: GitHub
+      type: repo
+      url: https://github.com/unbounce/omniauth-constantcontact2
+spec:
+  tier: "5"
+  type: custom
+  languages:
+    - ruby


### PR DESCRIPTION
Fleet codemod `manifest-distribute` (rule fix from unbounce/golden-path). One rule per PR; see the rule's `source` in the spec for why. Scanner will reflect the change on the next run.